### PR TITLE
Fix forum timer

### DIFF
--- a/lib/src/logic/forums.dart
+++ b/lib/src/logic/forums.dart
@@ -114,7 +114,7 @@ class Forums extends ChangeNotifier with IterableMixin<ForumThread>, BusyMixin {
   @override
   void addListener(VoidCallback listener) {
     if (!hasListeners && maxUpdatePeriod != null)
-      _timer = VariableTimer(maxUpdatePeriod, update);
+      _timer = VariableTimer('forums', maxUpdatePeriod, update);
     super.addListener(listener);
   }
 
@@ -242,7 +242,7 @@ class ForumThread extends ChangeNotifier with BusyMixin, IterableMixin<ForumMess
   @override
   void addListener(VoidCallback listener) {
     if (!hasListeners && maxUpdatePeriod != null)
-      _timer = VariableTimer(maxUpdatePeriod, update);
+      _timer = VariableTimer('forumThread', maxUpdatePeriod, update);
     super.addListener(listener);
   }
 

--- a/lib/src/logic/seamail.dart
+++ b/lib/src/logic/seamail.dart
@@ -155,7 +155,7 @@ class Seamail extends ChangeNotifier with IterableMixin<SeamailThread>, BusyMixi
   @override
   void addListener(VoidCallback listener) {
     if (!hasListeners && maxUpdatePeriod != null)
-      _timer = VariableTimer(maxUpdatePeriod, update);
+      _timer = VariableTimer('seamails', maxUpdatePeriod, update);
     super.addListener(listener);
   }
 
@@ -332,7 +332,7 @@ class SeamailThread extends ChangeNotifier with BusyMixin {
   @override
   void addListener(VoidCallback listener) {
     if (!hasListeners && maxUpdatePeriod != null)
-      _timer = VariableTimer(maxUpdatePeriod, update);
+      _timer = VariableTimer('seamailThread', maxUpdatePeriod, update);
     super.addListener(listener);
   }
 

--- a/lib/src/logic/stream.dart
+++ b/lib/src/logic/stream.dart
@@ -193,7 +193,7 @@ class TweetStream extends ChangeNotifier with BusyMixin {
   @override
   void addListener(VoidCallback listener) {
     if (!hasListeners)
-      _timer = VariableTimer(maxUpdatePeriod, _fetchForwards);
+      _timer = VariableTimer('Twitarr', maxUpdatePeriod, _fetchForwards);
     super.addListener(listener);
   }
 

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -81,10 +81,12 @@ mixin BusyMixin {
 }
 
 class VariableTimer {
-  VariableTimer(this.maxDuration, this.callback) {
+  VariableTimer(this.name, this.maxDuration, this.callback) {
     interested();
     Timer.run(tick);
   }
+
+  final String name;
 
   final Duration maxDuration;
 
@@ -95,6 +97,7 @@ class VariableTimer {
 
   void tick() async {
     _currentPeriod *= 1.5;
+    debugPrint("$name is ticking: $_currentPeriod interval.");
     await callback();
     if (_currentPeriod > maxDuration)
       _currentPeriod = maxDuration;
@@ -102,10 +105,12 @@ class VariableTimer {
   }
 
   void interested() {
+    debugPrint("$name is timing: 3 second interval.");
     _currentPeriod = const Duration(seconds: 3);
   }
 
   void cancel() {
+    debugPrint("$name's timer is canceled.");
     _timer?.cancel();
     _timer = null;
   }

--- a/lib/src/views/comms.dart
+++ b/lib/src/views/comms.dart
@@ -24,8 +24,9 @@ class CommsView extends StatelessWidget implements View {
   @override
   Widget buildTabIcon(BuildContext context) {
     final Seamail seamail = Cruise.of(context).seamail;
+    final Forums forums = Cruise.of(context).forums;
     return AnimatedBuilder(
-      animation: seamail,
+      animation: Listenable.merge(<Listenable>[seamail, forums]),
       builder: (BuildContext context, Widget child) {
         return Badge(
           child: child,

--- a/lib/src/views/comms.dart
+++ b/lib/src/views/comms.dart
@@ -24,9 +24,8 @@ class CommsView extends StatelessWidget implements View {
   @override
   Widget buildTabIcon(BuildContext context) {
     final Seamail seamail = Cruise.of(context).seamail;
-    final Forums forums = Cruise.of(context).forums;
     return AnimatedBuilder(
-      animation: Listenable.merge(<Listenable>[seamail, forums]),
+      animation: seamail,
       builder: (BuildContext context, Widget child) {
         return Badge(
           child: child,


### PR DESCRIPTION
 #109 The messages page refresh is causing the forum polling timer to reset every ~30s. This happens because the refresh logic unregisters the last listener on the forum object, causing it to cancel and deleted it's timer. After the refresh it adds a new listener but the polling interval gets reset back to 3s.  This is a potential DOS against the server, that forum list isn't going to be short and a lot of devices will end up requesting it every 3 seconds. It's not going to be great for app performance either.

The seamail timer doesn't have this problem because it has multiple listeners registered and at least one stays attached during the refresh. Adding the same listeners to the forums was the easiest way to mitigate the issue. Any other ideas?