### PR TITLE
Fix account validation

### DIFF
--- a/lib/src/views/create_account.dart
+++ b/lib/src/views/create_account.dart
@@ -45,7 +45,7 @@ class _CreateAccountState extends State<CreateAccount> {
            AuthenticatedUser.isValidPassword(_password1.text) &&
            (_password1.text == _password2.text) &&
            AuthenticatedUser.isValidRegistrationCode(_registrationCode.text) &&
-           _displayName.text == '' || AuthenticatedUser.isValidDisplayName(_displayName.text);
+           (_displayName.text == '' || AuthenticatedUser.isValidDisplayName(_displayName.text));
   }
 
   void _createAccount() async {


### PR DESCRIPTION
 #101 Because of the missing parens only a valid display name was required before the Create Account button would be enabled.