### PR TITLE
Fix numeric passwords

### DIFF
--- a/lib/src/logic/disk_store.dart
+++ b/lib/src/logic/disk_store.dart
@@ -60,7 +60,7 @@ class DiskDataStore extends DataStore {
         return null;
       return Credentials(
         username: results['username'] as String,
-        password: results['password'] as String,
+        password: results['password'].toString(), // Passwords may be numbers and dynamic may retrieve them as such.
         key: results['key'] as String,
         loginTimestamp: DateTime.fromMillisecondsSinceEpoch(results['loginTimestamp'] as int),
       );


### PR DESCRIPTION
 #115 The user login is not remembered after an app restart if the password consists only of numbers. They have to log in every time.

Username: newuser0
Password: 123456

There's an exception at app load time:
`type 'int' is not a subtype of type 'String' in type cast`
https://github.com/seamonkeysocial/cruisemonkey/blob/48691853f42af5687b1383f118bae6ec7d482043/lib/src/logic/disk_store.dart#L63

`results` is: `{username: newuser0, password: 123456, key: newuser0:889bf4174586bc4d81ba493c30156c76433ca880, loginTimestamp: 1550556140925}`
```
0 = {_List} size = 4
 0 = "newuser0"
 1 = 123456
 2 = "newuser0:889bf4174586bc4d81ba493c30156c76433ca880"
 3 = 1550556140925
```

Note the password is retrieved as a number rather than a string so that explains the exception. 

It was a string when it went in:
https://github.com/seamonkeysocial/cruisemonkey/blob/48691853f42af5687b1383f118bae6ec7d482043/lib/src/logic/disk_store.dart#L44
```
value = {Credentials} Credentials(newuser0)
 username = "newuser0"
 password = "123456"
 key = "newuser0:889bf4174586bc4d81ba493c30156c76433ca880"
 loginTimestamp = {DateTime} 2019-02-18 22:11:14.635821
```

Some part of the `dynamic` storage or retrieval process is messing it up. Calling toString() on the result fixes it.