### PR TITLE
Add missing timer state transitions

### DIFF
--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -164,9 +164,11 @@ class VariableTimer {
       case _VariableTimerState.disabling:
         return;
       case _VariableTimerState.enabled:
+        _state = _VariableTimerState.disabling;
         scheduleMicrotask(_disable);
         return;
       case _VariableTimerState.ticking:
+        _state = _VariableTimerState.tickingDisabling;
         scheduleMicrotask(_disable);
         return;
       case _VariableTimerState.tickingDisabling:


### PR DESCRIPTION
 #118 introduced some state machines to manage the timer activity. However it's missing these two state transitions to disable the timers. Without them every timer ever started will keep ticking until you force quit the app.