### PR TITLE
Fix lots of bugs

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -34,7 +34,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 28
         versionCode 1
-        versionName "JoCo 2019 v1.2"
+        versionName "JoCo 2019 v1.3"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     signingConfigs {

--- a/lib/src/logic/disk_store.dart
+++ b/lib/src/logic/disk_store.dart
@@ -40,10 +40,10 @@ class DiskDataStore extends DataStore {
     return Progress<void>((ProgressController<void> completer) async {
       final Database database = await _database;
       await database.update('credentials', <String, dynamic>{
-        'username': value.username,
-        'password': value.password,
-        'key': value.key,
-        'loginTimestamp': value.loginTimestamp.millisecondsSinceEpoch,
+        'username': value?.username,
+        'password': value?.password,
+        'key': value?.key,
+        'loginTimestamp': value?.loginTimestamp?.millisecondsSinceEpoch,
       });
     });
   }
@@ -165,7 +165,7 @@ class DiskDataStore extends DataStore {
         },
         conflictAlgorithm: ConflictAlgorithm.replace,
       );
-   });
+    });
   }
 
   Uint8List _encodeValue(dynamic value) {

--- a/lib/src/logic/forums.dart
+++ b/lib/src/logic/forums.dart
@@ -16,27 +16,27 @@ typedef ThreadReadCallback = void Function(String threadId);
 class Forums extends ChangeNotifier with IterableMixin<ForumThread>, BusyMixin {
   Forums(
     this._twitarr,
-    this._credentials,
-    this._photoManager, {
+    this._credentials, {
+    @required this.photoManager,
     this.maxUpdatePeriod = const Duration(minutes: 10),
     @required this.onError,
   }) : assert(onError != null),
        assert(_twitarr != null),
-       assert(_photoManager != null) {
+       assert(photoManager != null) {
     _timer = VariableTimer(maxUpdatePeriod, update);
   }
 
   Forums.empty(
   ) : _twitarr = null,
       _credentials = null,
-      _photoManager = null,
+      photoManager = null,
       maxUpdatePeriod = null,
       onError = null;
 
   final Twitarr _twitarr;
   final Credentials _credentials;
-  final PhotoManager _photoManager;
 
+  final PhotoManager photoManager;
   final Duration maxUpdatePeriod;
   final ErrorCallback onError;
 
@@ -64,7 +64,7 @@ class Forums extends ChangeNotifier with IterableMixin<ForumThread>, BusyMixin {
             _timer.interested();
           removedThreads.remove(thread);
         } else {
-          _threads[threadSummary.id] = ForumThread.from(threadSummary, this, _twitarr, _credentials, _photoManager);
+          _threads[threadSummary.id] = ForumThread.from(threadSummary, this, _twitarr, _credentials, photoManager);
         }
       }
       removedThreads.forEach(_threads.remove);
@@ -96,7 +96,7 @@ class Forums extends ChangeNotifier with IterableMixin<ForumThread>, BusyMixin {
       );
       _timer.interested();
       if (!_threads.containsKey(thread.id)) {
-        _threads[thread.id] = ForumThread.from(thread, this, _twitarr, _credentials, _photoManager);
+        _threads[thread.id] = ForumThread.from(thread, this, _twitarr, _credentials, photoManager);
         notifyListeners();
       }
       return _threads[thread.id];
@@ -163,6 +163,8 @@ class ForumThread extends ChangeNotifier with BusyMixin, IterableMixin<ForumMess
 
   String get subject => _subject ?? '';
   String _subject;
+
+  bool get hasUnread => unreadCount > 0;
 
   int get unreadCount => _unreadCount ?? 0;
   int _unreadCount;

--- a/lib/src/logic/store.dart
+++ b/lib/src/logic/store.dart
@@ -7,6 +7,7 @@ enum Setting {
   debugNetworkReliability,
   debugTimeDilation,
   notificationFreshnessToken,
+  lastNotificationsCheck,
 }
 
 typedef FreshnessCallback = Future<int> Function(int token);

--- a/lib/src/network/rest.dart
+++ b/lib/src/network/rest.dart
@@ -18,6 +18,8 @@ import 'twitarr.dart';
 const String _kShipTwitarrUrl = 'http://joco.hollandamerica.com/';
 const String _kDevTwitarrUrl = 'http://twitarrdev.wookieefive.net:3000/';
 
+const bool _debugVerbose = false;
+
 class RestTwitarrConfiguration extends TwitarrConfiguration {
   const RestTwitarrConfiguration({ @required this.baseUrl }) : assert(baseUrl != null);
 
@@ -1169,7 +1171,8 @@ class RestTwitarr implements Twitarr {
         .transform(utf8.decoder)
         .join();
       assert(() {
-        debugPrint('<<< ${response.statusCode} $result');
+        if (_debugVerbose)
+          debugPrint('<<< ${response.statusCode} $result');
         return true;
       }());
       return result;
@@ -1228,7 +1231,11 @@ class RestTwitarr implements Twitarr {
                      : bodyParts != null ? bodyParts.fold(0, (int length, Uint8List part) => length + part.length)
                      : null;
     assert(() {
-      debugPrint('>>> $method $url (body length: $length)');
+      if (_debugVerbose) {
+        debugPrint('>>> $method $url (body length: $length)');
+      } else {
+        debugPrint('>>> $method ${url.path}');
+      }
       return true;
     }());
     try {

--- a/lib/src/progress.dart
+++ b/lib/src/progress.dart
@@ -4,6 +4,8 @@ import 'package:flutter/foundation.dart';
 
 import 'utils.dart';
 
+const bool _verbose = false;
+
 enum _ProgressIndex { idle, starting, active, failed, successful }
 
 abstract class ProgressValue<T> {
@@ -260,7 +262,16 @@ class ProgressController<T> {
 
   void completeError(dynamic error, StackTrace stackTrace) {
     assert(() {
-      debugPrint('Caught exception:\n$error\n${stackTrace}Reporting exception as failed progress.');
+      if (_verbose) {
+        debugPrint(
+          '$runtimeType converted exception into failed progress.\n'
+          'Message: $error\n'
+          'Exception raised from:\n'
+          '${stackTrace ?? "<null>\n"}'
+          'Exception reported from:\n'
+          '${StackTrace.current ?? "<null>\n"}'
+        );
+      }
       return true;
     }());
     _update(FailedProgress(error is Exception ? error : Exception(error.toString()), stackTrace));

--- a/lib/src/views/calendar.dart
+++ b/lib/src/views/calendar.dart
@@ -69,6 +69,14 @@ class _CalendarViewState extends State<CalendarView> with SingleTickerProviderSt
     return ContinuousProgressBuilder<Calendar>(
       progress: Cruise.of(context).calendar,
       onRetry: () { Cruise.of(context).forceUpdate(); },
+      idleChild: Center(
+        child: FlatButton(
+          child: const Text('LOAD CALENDAR'),
+          onPressed: () {
+            Cruise.of(context).forceUpdate();
+          },
+        ),
+      ),
       builder: (BuildContext context, Calendar calendar) {
         return LayoutBuilder(
           builder: (BuildContext context, BoxConstraints constraints) {
@@ -170,7 +178,7 @@ class _CalendarViewInternalsState extends State<_CalendarViewInternals> {
             bottom: false,
             sliver: EventList(
               events: widget.beforeEvents,
-              fallback: widget.excuse == null ? iconAndLabel(icon: Icons.sentiment_satisfied, message: 'The cruise has not yet begun') : null,
+              fallback: widget.excuse == null ? iconAndLabel(icon: Icons.sentiment_satisfied, message: widget.filtered ? 'No earlier marked events' : 'The cruise has not yet begun') : null,
               now: widget.now,
               isLoggedIn: widget.isLoggedIn,
               onSetFavorite: widget.onFavorite,

--- a/lib/src/views/profile.dart
+++ b/lib/src/views/profile.dart
@@ -3,9 +3,11 @@ import 'dart:math' as math;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
+import '../logic/cruise.dart';
 import '../models/user.dart';
 import '../progress.dart';
 import '../widgets.dart';
+import 'comms.dart';
 
 class Profile extends StatefulWidget {
   const Profile({
@@ -23,14 +25,28 @@ class Profile extends StatefulWidget {
 class _ProfileState extends State<Profile> {
   Progress<User> _user;
 
+  CruiseModel _cruise;
+
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    _start();
+    final CruiseModel newCruise = Cruise.of(context);
+    if (newCruise != _cruise) {
+      _cruise?.removeListener(_start);
+      _cruise = newCruise;
+      _cruise.addListener(_start);
+      _start();
+    }
+  }
+
+  @override
+  void dispose() {
+    _cruise.removeListener(_start);
+    super.dispose();
   }
 
   void _start() {
-    _user = Cruise.of(context).fetchProfile(widget.user.username);
+    _user = _cruise.fetchProfile(widget.user.username);
   }
 
   static bool _missing(String value) => value == null || value == '';
@@ -41,82 +57,108 @@ class _ProfileState extends State<Profile> {
       appBar: AppBar(
         title: Text('${widget.user}'),
       ),
-      body: ProgressBuilder<User>(
-        progress: _user,
-        onRetry: () {
-          setState(_start);
-        },
-        builder: (BuildContext context, User user) {
-          final TextStyle italic = DefaultTextStyle.of(context).style.copyWith(fontStyle: FontStyle.italic);
-          final Widget none = Text('none', style: italic);
-          final Widget notSpecified = Text('not specified', style: italic);
-          return ListView(
-            padding: const EdgeInsets.all(24.0),
-            children: <Widget>[
-              LayoutBuilder(
-                builder: (BuildContext context, BoxConstraints constraints) {
-                  return Cruise.of(context).avatarFor(<User>[user], size: math.min(256.0, constraints.maxWidth), enabled: false);
-                },
-              ),
-              const SizedBox(height: 24.0),
-              Table(
-                columnWidths: const <int, TableColumnWidth>{
-                  0: IntrinsicColumnWidth(flex: 1.0),
-                  1: FixedColumnWidth(24.0),
-                },
-                children: <TableRow>[
-                  TableRow(
-                    children: <Widget>[
-                      const Text('Username: ', textAlign: TextAlign.end),
-                      const SizedBox(width: 24.0, height: 24.0),
-                      Text(user.username),
-                    ],
-                  ),
-                  TableRow(
-                    children: <Widget>[
-                      const Text('Display name: ', textAlign: TextAlign.end),
-                      const SizedBox(width: 24.0, height: 24.0),
-                      user.displayName == user.username ? none : Text(user.displayName),
-                    ],
-                  ),
-                  TableRow(
-                    children: <Widget>[
-                      const Text('Real name: ', textAlign: TextAlign.end),
-                      const SizedBox(width: 24.0, height: 24.0),
-                      _missing(user.realName) ? notSpecified : Text(user.realName),
-                    ],
-                  ),
-                  TableRow(
-                    children: <Widget>[
-                      const Text('Pronouns: ', textAlign: TextAlign.end),
-                      const SizedBox(width: 24.0, height: 24.0),
-                      _missing(user.pronouns) ? notSpecified : Text(user.pronouns),
-                    ],
-                  ),
-                  TableRow(
-                    children: <Widget>[
-                      const Text('Room number: ', textAlign: TextAlign.end),
-                      const SizedBox(width: 24.0, height: 24.0),
-                      _missing(user.roomNumber) ? notSpecified : Text(user.roomNumber),
-                    ],
-                  ),
-                  TableRow(
-                    children: <Widget>[
-                      const Text('Home location: ', textAlign: TextAlign.end),
-                      const SizedBox(width: 24.0, height: 24.0),
-                      _missing(user.homeLocation) ? notSpecified : Text(user.homeLocation),
-                    ],
-                  ),
-                  TableRow(
-                    children: <Widget>[
-                      const Text('E-mail: ', textAlign: TextAlign.end),
-                      const SizedBox(width: 24.0, height: 24.0),
-                      _missing(user.email) ? notSpecified : Text(user.email),
-                    ],
-                  ),
-                ],
-              ),
-            ],
+      body: ValueListenableBuilder<ProgressValue<AuthenticatedUser>>(
+        valueListenable: Cruise.of(context).user.best,
+        builder: (BuildContext context, ProgressValue<AuthenticatedUser> user, Widget child) {
+          User currentUser;
+          if (user is SuccessfulProgress<AuthenticatedUser>)
+            currentUser = user.value;
+          return ProgressBuilder<User>(
+            progress: _user,
+            onRetry: () {
+              setState(_start);
+            },
+            builder: (BuildContext context, User user) {
+              final TextStyle italic = DefaultTextStyle.of(context).style.copyWith(fontStyle: FontStyle.italic);
+              final Widget none = Text('none', style: italic);
+              final Widget notSpecified = Text('not specified', style: italic);
+              final List<Widget> children = <Widget>[
+                LayoutBuilder(
+                  builder: (BuildContext context, BoxConstraints constraints) {
+                    return Cruise.of(context).avatarFor(<User>[user], size: math.min(256.0, constraints.maxWidth), enabled: false);
+                  },
+                ),
+                const SizedBox(height: 24.0),
+                Table(
+                  columnWidths: const <int, TableColumnWidth>{
+                    0: IntrinsicColumnWidth(flex: 1.0),
+                    1: FixedColumnWidth(24.0),
+                  },
+                  children: <TableRow>[
+                    TableRow(
+                      children: <Widget>[
+                        const Text('Username: ', textAlign: TextAlign.end),
+                        const SizedBox(width: 24.0, height: 24.0),
+                        Text(user.username),
+                      ],
+                    ),
+                    TableRow(
+                      children: <Widget>[
+                        const Text('Display name: ', textAlign: TextAlign.end),
+                        const SizedBox(width: 24.0, height: 24.0),
+                        user.displayName == user.username ? none : Text(user.displayName),
+                      ],
+                    ),
+                    TableRow(
+                      children: <Widget>[
+                        const Text('Real name: ', textAlign: TextAlign.end),
+                        const SizedBox(width: 24.0, height: 24.0),
+                        _missing(user.realName) ? notSpecified : Text(user.realName),
+                      ],
+                    ),
+                    TableRow(
+                      children: <Widget>[
+                        const Text('Pronouns: ', textAlign: TextAlign.end),
+                        const SizedBox(width: 24.0, height: 24.0),
+                        _missing(user.pronouns) ? notSpecified : Text(user.pronouns),
+                      ],
+                    ),
+                    TableRow(
+                      children: <Widget>[
+                        const Text('Room number: ', textAlign: TextAlign.end),
+                        const SizedBox(width: 24.0, height: 24.0),
+                        _missing(user.roomNumber) ? notSpecified : Text(user.roomNumber),
+                      ],
+                    ),
+                    TableRow(
+                      children: <Widget>[
+                        const Text('Home location: ', textAlign: TextAlign.end),
+                        const SizedBox(width: 24.0, height: 24.0),
+                        _missing(user.homeLocation) ? notSpecified : Text(user.homeLocation),
+                      ],
+                    ),
+                    TableRow(
+                      children: <Widget>[
+                        const Text('E-mail: ', textAlign: TextAlign.end),
+                        const SizedBox(width: 24.0, height: 24.0),
+                        _missing(user.email) ? notSpecified : Text(user.email),
+                      ],
+                    ),
+                  ],
+                ),
+              ];
+              if (user.sameAs(currentUser)) {
+                children.add(const SizedBox(height: 24.0));
+                children.add(LabeledIconButton(
+                  onPressed: () { Navigator.pushNamed(context, '/profile-editor'); },
+                  icon: const Icon(Icons.edit),
+                  label: const Text('EDIT PROFILE'),
+                ));
+              } else if (currentUser != null) {
+                children.add(const SizedBox(height: 24.0));
+                children.add(LabeledIconButton(
+                  onPressed: () async {
+                    await CommsView.createNewSeamail(context, currentUser, others: <User>[user]);
+                  },
+                  icon: const Icon(Icons.mail),
+                  label: const Text('START CONVERSATION'),
+                ));
+              }
+              return ListView(
+                padding: const EdgeInsets.all(24.0),
+                children: children,
+              );
+            },
           );
         },
       ),

--- a/lib/src/views/seamail.dart
+++ b/lib/src/views/seamail.dart
@@ -331,9 +331,11 @@ class StartSeamailView extends StatefulWidget {
   const StartSeamailView({
     Key key,
     this.currentUser,
+    this.initialOtherUsers,
   }) : super(key: key);
 
   final User currentUser;
+  final List<User> initialOtherUsers;
 
   @override
   _StartSeamailViewState createState() => _StartSeamailViewState();
@@ -356,6 +358,8 @@ class _StartSeamailViewState extends State<StartSeamailView> {
   void initState() {
     super.initState();
     _users.add(widget.currentUser);
+    if (widget.initialOtherUsers != null)
+      _users.addAll(widget.initialOtherUsers);
   }
 
   @override

--- a/lib/src/views/stream.dart
+++ b/lib/src/views/stream.dart
@@ -89,19 +89,13 @@ class _TweetStreamViewState extends State<TweetStreamView> with TickerProviderSt
   }
 
   @override
-  void initState() {
-    super.initState();
-    _scrollController = ScrollController()
-      ..addListener(_scrolled);
-  }
-
-  @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    final TweetStream newStream = Cruise.of(context).createTweetStream();
+    final TweetStream newStream = Cruise.of(context).tweetStream;
     if (newStream != _stream) {
-      if (_scrollController.hasClients)
-        _scrollController.jumpTo(0.0);
+      _scrollController?.dispose();
+      _scrollController = ScrollController()
+        ..addListener(_scrolled);
       _stream = newStream;
       _stream.pin(false);
     }
@@ -146,6 +140,7 @@ class _TweetStreamViewState extends State<TweetStreamView> with TickerProviderSt
               animation: _stream,
               builder: (BuildContext context, Widget child) {
                 return ListView.custom(
+                  key: ObjectKey(_stream),
                   controller: _scrollController,
                   reverse: true,
                   cacheExtent: 1000.0,

--- a/lib/src/views/user.dart
+++ b/lib/src/views/user.dart
@@ -135,7 +135,21 @@ class _UserViewState extends State<UserView> {
           header = Align(
             key: _errorHeader,
             alignment: Alignment.bottomCenter,
-            child: Text('${wrapError(_bestUserValue.error)}\n'),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: <Widget>[
+                iconAndLabel(icon: Icons.warning, message: 'Could not log in:\n${wrapError(_bestUserValue.error)}'),
+                Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: FlatButton(
+                    child: const Text('RETRY'),
+                    onPressed: () {
+                      Cruise.of(context).retryUserLogin();
+                    },
+                  ),
+                ),
+              ],
+            ),
           );
           loggedIn = false;
         } else {
@@ -283,7 +297,7 @@ class _UserViewState extends State<UserView> {
                       showAboutDialog(
                         context: context,
                         applicationName: 'Cruise Monkey',
-                        applicationVersion: 'JoCo 2019 v1.2',
+                        applicationVersion: 'JoCo 2019 v1.3',
                         applicationIcon: Image.asset('images/cruise_monkey.png', width: 96.0),
                         children: <Widget>[
                           const Text('A project of the Seamonkey Social group.'),

--- a/lib/src/widgets.dart
+++ b/lib/src/widgets.dart
@@ -1243,7 +1243,7 @@ class PhotoImage extends StatelessWidget {
     return Padding(
       padding: const EdgeInsets.only(top: 8.0),
       child: AspectRatio(
-        aspectRatio: photo.mediumSize.width / photo.mediumSize.height,
+        aspectRatio: photo.mediumSize.width == 0 ? 1.0 : photo.mediumSize.width / photo.mediumSize.height,
         child: ClipRRect(
           borderRadius: BorderRadius.circular(8.0),
           child: GestureDetector(

--- a/test/loggers.dart
+++ b/test/loggers.dart
@@ -276,7 +276,7 @@ class LoggingTwitarr extends Twitarr {
     int limit = 100,
   }) {
     log.add('getStream');
-    return null;
+    return const Progress<StreamSliceSummary>.idle();
   }
 
   @override

--- a/test/mocks.dart
+++ b/test/mocks.dart
@@ -147,7 +147,7 @@ class TestCruiseModel extends ChangeNotifier implements CruiseModel {
   Forums _forums;
 
   @override
-  TweetStream createTweetStream() => TweetStream(null, null, photoManager: this);
+  TweetStream get tweetStream => TweetStream(null, null, photoManager: this);
 
   @override
   Progress<String> createAccount({
@@ -166,6 +166,9 @@ class TestCruiseModel extends ChangeNotifier implements CruiseModel {
   }) {
     return const Progress<Credentials>.idle();
   }
+
+  @override
+  void retryUserLogin() { }
 
   @override
   Progress<Credentials> logout({ bool serverChanging = false }) {


### PR DESCRIPTION
- Update version number.

- Don't overload the server with notification checks. Sometimes weird
  things seem to happen. I want to make sure they don't have knock-on
  effects on the server.

- Make the notifications open the relevant thread more reliably.

- Fix the issue of the stream resetting when coming back from looking
  at an image.

- Retry button on failed login.

- Load Calendar button on failed login.

- Reset saved credentials on logout.

- Reduce verbosity of debug logs.

- Fix message when filtering calendar and there's no older marked
  events.

- Show dividers on comms page on iOS.

- Edit profile from own profile view.

- Start conversation from someone else's profile view.

- Make forums and seamails more consistent in their display in the
  summary.

- Reduce how much we hit the server when looking at profiles.