### PR TITLE
add NSAppTransportSecurity key

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -51,5 +51,10 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+    		<key>NSAllowsArbitraryLoads</key>
+    		<true/>
+	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
You *might* want to add this one to allow HTTP transport to the server in addition to HTTPS for maximum on-board flexibility. I'd recommend it, but it does require a sentence or two of justification when submitting, and may well trigger additional review (thus lag).